### PR TITLE
Update coding guidelines with naming and import conventions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,13 +39,15 @@ make help             # Show all available commands
 
 ## Coding Guidelines
 
+**Absolute imports.** Use absolute imports throughout the codebase (e.g., `from lean_explore.api.client import Client`). Avoid relative imports. All imports must be at the top of the file.
+
+**Naming.** Avoid abbreviations in variable, function, and class names—use full words for clarity (e.g., `configuration` not `config`, `document` not `doc`). For acronyms in class names, capitalize only the first letter (e.g., `ReplHandler`, `McpServer`, `HtmlParser`).
+
 **Documentation.** Every module must have a module-level docstring. Every method which is not self-explanatory must have a Google-style docstring. Public-facing methods must use detailed docstrings that explain parameters, return values, and exceptions.
 
 **Inline comments.** Add inline comments for complex code and questions that will come up during code review.
 
-**Methods.** Keep method bodies under 40 lines (soft limit). Write self-documenting code: use descriptive variable and function names
-
-**Imports.** All imports must be at the top of the file.
+**Methods.** Keep method bodies under 40 lines (soft limit). Write self-documenting code: use descriptive variable and function names.
 
 **Logging.** Use loggers and not print statements when needing to print to console.
 

--- a/src/lean_explore/cli/main.py
+++ b/src/lean_explore/cli/main.py
@@ -12,14 +12,13 @@ import sys
 import textwrap
 from typing import Optional
 
-import httpx
 import typer
 from rich.console import Console
 from rich.panel import Panel
 
 from lean_explore.api import ApiClient
 from lean_explore.cli import data_commands
-from lean_explore.search.types import SearchResponse, SearchResult
+from lean_explore.search.types import SearchResponse
 
 
 def async_command(f):
@@ -130,7 +129,11 @@ def _display_search_results(response: SearchResponse, display_limit: int = 5):
     )
 
     num_results_to_show = min(len(response.results), display_limit)
-    time_info = f"Time: {response.processing_time_ms}ms" if response.processing_time_ms else ""
+    time_info = (
+        f"Time: {response.processing_time_ms}ms"
+        if response.processing_time_ms
+        else ""
+    )
     console.print(
         f"Showing {num_results_to_show} of {response.count} results. {time_info}"
     )
@@ -151,9 +154,11 @@ def _display_search_results(response: SearchResponse, display_limit: int = 5):
         console.print(
             f"[bold cyan]Module:[/bold cyan] [green]{item.module}[/green]"
         )
-        console.print(
-            f"[bold cyan]Source:[/bold cyan] [link={item.source_link}]{item.source_link}[/link]"
+        source_formatted = (
+            f"[bold cyan]Source:[/bold cyan] "
+            f"[link={item.source_link}]{item.source_link}[/link]"
         )
+        console.print(source_formatted)
 
         if item.source_text:
             formatted_code = _format_text_for_fixed_panel(

--- a/src/lean_explore/extract/__init__.py
+++ b/src/lean_explore/extract/__init__.py
@@ -1,0 +1,5 @@
+"""Lean declaration extraction and processing tools.
+
+This package contains modules for extracting, parsing, and enriching
+Lean mathematical declarations from documentation files.
+"""

--- a/src/lean_explore/extract/embeddings.py
+++ b/src/lean_explore/extract/embeddings.py
@@ -9,7 +9,14 @@ Reads declarations from the database and generates embeddings for:
 
 import logging
 
-from rich.progress import Progress, SpinnerColumn, TextColumn, BarColumn, TaskProgressColumn, TimeRemainingColumn
+from rich.progress import (
+    BarColumn,
+    Progress,
+    SpinnerColumn,
+    TaskProgressColumn,
+    TextColumn,
+    TimeRemainingColumn,
+)
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
@@ -125,8 +132,9 @@ async def _process_batch(
         await session.execute(update(Declaration), list(updates.values()))
         await session.commit()
 
+    responses = [name_response, info_response, source_response, doc_response]
     total = sum(
-        len(response.embeddings) for response in [name_response, info_response, source_response, doc_response] if response
+        len(response.embeddings) for response in responses if response
     )
     return total
 
@@ -146,7 +154,10 @@ async def generate_embeddings(
         limit: Maximum number of declarations to process (None for all)
     """
     client = EmbeddingClient(model_name=model_name)
-    logger.info(f"Starting embedding generation with {client.model_name} on {client.device}")
+    logger.info(
+        f"Starting embedding generation with {client.model_name} "
+        f"on {client.device}"
+    )
 
     async with AsyncSession(engine) as session:
         declarations = await _get_declarations_needing_embeddings(session, limit)

--- a/src/lean_explore/extract/pagerank.py
+++ b/src/lean_explore/extract/pagerank.py
@@ -4,7 +4,13 @@ import json
 import logging
 
 import networkx as nx
-from rich.progress import Progress, SpinnerColumn, TextColumn, BarColumn, TaskProgressColumn
+from rich.progress import (
+    BarColumn,
+    Progress,
+    SpinnerColumn,
+    TaskProgressColumn,
+    TextColumn,
+)
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
@@ -37,13 +43,19 @@ async def _build_dependency_graph(session: AsyncSession) -> nx.DiGraph:
     # Add edges
     for decl in declarations:
         if decl.dependencies:
-            deps = json.loads(decl.dependencies) if isinstance(decl.dependencies, str) else decl.dependencies
+            if isinstance(decl.dependencies, str):
+                deps = json.loads(decl.dependencies)
+            else:
+                deps = decl.dependencies
             for dep_name in deps:
                 if dep_name in name_to_id:
                     # Edge from dependent to dependency
                     graph.add_edge(decl.id, name_to_id[dep_name])
 
-    logger.info(f"Built graph with {graph.number_of_nodes()} nodes and {graph.number_of_edges()} edges")
+    logger.info(
+        f"Built graph with {graph.number_of_nodes()} nodes and "
+        f"{graph.number_of_edges()} edges"
+    )
     return graph
 
 

--- a/src/lean_explore/extract/schemas.py
+++ b/src/lean_explore/extract/schemas.py
@@ -72,16 +72,24 @@ class Declaration(Base):
     informalization: Mapped[str | None] = mapped_column(Text, nullable=True)
     """Natural language description of the declaration."""
 
-    name_embedding: Mapped[list[float] | None] = mapped_column(Vector(768), nullable=True)
+    name_embedding: Mapped[list[float] | None] = mapped_column(
+        Vector(768), nullable=True
+    )
     """768-dimensional embedding of the declaration name."""
 
-    informalization_embedding: Mapped[list[float] | None] = mapped_column(Vector(768), nullable=True)
+    informalization_embedding: Mapped[list[float] | None] = mapped_column(
+        Vector(768), nullable=True
+    )
     """768-dimensional embedding of the informalization text."""
 
-    source_text_embedding: Mapped[list[float] | None] = mapped_column(Vector(768), nullable=True)
+    source_text_embedding: Mapped[list[float] | None] = mapped_column(
+        Vector(768), nullable=True
+    )
     """768-dimensional embedding of the source text."""
 
-    docstring_embedding: Mapped[list[float] | None] = mapped_column(Vector(768), nullable=True)
+    docstring_embedding: Mapped[list[float] | None] = mapped_column(
+        Vector(768), nullable=True
+    )
     """768-dimensional embedding of the docstring."""
 
     pagerank: Mapped[float | None] = mapped_column(Float, nullable=True)

--- a/src/lean_explore/mcp/app.py
+++ b/src/lean_explore/mcp/app.py
@@ -69,7 +69,10 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[AppContext]:
 mcp_app = FastMCP(
     "LeanExploreMCPServer",
     version="0.1.0",
-    description="MCP Server for Lean Explore, providing tools to search Lean declarations.",
+    description=(
+        "MCP Server for Lean Explore, "
+        "providing tools to search Lean declarations."
+    ),
     lifespan=app_lifespan,
 )
 

--- a/src/lean_explore/mcp/tools.py
+++ b/src/lean_explore/mcp/tools.py
@@ -84,13 +84,19 @@ async def get_by_id(
 
     if not hasattr(backend, "get_by_id"):
         logger.error("Backend service does not have a 'get_by_id' method.")
-        raise RuntimeError("Get by ID functionality not available on configured backend.")
+        raise RuntimeError(
+            "Get by ID functionality not available on configured backend."
+        )
 
     # Call backend get_by_id (handle both async and sync)
     if asyncio.iscoroutinefunction(backend.get_by_id):
-        result: SearchResult | None = await backend.get_by_id(declaration_id=declaration_id)
+        result: SearchResult | None = await backend.get_by_id(
+            declaration_id=declaration_id
+        )
     else:
-        result: SearchResult | None = backend.get_by_id(declaration_id=declaration_id)
+        result: SearchResult | None = backend.get_by_id(
+            declaration_id=declaration_id
+        )
 
     # Return as dict for MCP, or None
     return result.model_dump(exclude_none=True) if result else None

--- a/src/lean_explore/search/engine.py
+++ b/src/lean_explore/search/engine.py
@@ -8,8 +8,8 @@ import asyncio
 import logging
 from typing import List, Optional
 
-from sqlalchemy import create_engine, select, text
-from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
 
 from lean_explore import defaults
 from lean_explore.extract.schemas import Declaration


### PR DESCRIPTION
Add explicit guidelines for absolute imports, avoiding abbreviations in naming, and acronym capitalization in class names. Consolidate import-related guidelines under a single section.