### PR TITLE
Centralize utility imports in lean_explore.util

### DIFF
--- a/src/lean_explore/extract/__main__.py
+++ b/src/lean_explore/extract/__main__.py
@@ -9,7 +9,6 @@ This module provides functions to coordinate the complete data extraction pipeli
 
 import logging
 import os
-import sys
 
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 
@@ -18,18 +17,9 @@ from lean_explore.extract.embeddings import generate_embeddings
 from lean_explore.extract.informalize import informalize_declarations
 from lean_explore.extract.pagerank import calculate_pagerank
 from lean_explore.models import Base
+from lean_explore.util import setup_logging
 
 logger = logging.getLogger(__name__)
-
-
-def setup_logging(verbose: bool) -> None:
-    """Configure logging for the extraction pipeline."""
-    level = logging.DEBUG if verbose else logging.INFO
-    logging.basicConfig(
-        level=level,
-        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-        handlers=[logging.StreamHandler(sys.stdout)],
-    )
 
 
 async def create_database_schema(engine: AsyncEngine) -> None:

--- a/src/lean_explore/extract/embeddings.py
+++ b/src/lean_explore/extract/embeddings.py
@@ -21,7 +21,7 @@ from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 from lean_explore.models import Declaration
-from lean_explore.util.embedding_client import EmbeddingClient
+from lean_explore.util import EmbeddingClient
 
 logger = logging.getLogger(__name__)
 

--- a/src/lean_explore/extract/informalize.py
+++ b/src/lean_explore/extract/informalize.py
@@ -22,7 +22,7 @@ from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, create_async_engine
 
 from lean_explore.models import Declaration
-from lean_explore.util.openrouter_client import OpenRouterClient
+from lean_explore.util import OpenRouterClient
 
 logger = logging.getLogger(__name__)
 

--- a/src/lean_explore/search/engine.py
+++ b/src/lean_explore/search/engine.py
@@ -11,7 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, create_async_engin
 
 from lean_explore.config import Config
 from lean_explore.models import Declaration, SearchResult
-from lean_explore.util.embedding_client import EmbeddingClient
+from lean_explore.util import EmbeddingClient
 
 logger = logging.getLogger(__name__)
 

--- a/src/lean_explore/util/__init__.py
+++ b/src/lean_explore/util/__init__.py
@@ -1,0 +1,7 @@
+"""Shared utilities for lean_explore."""
+
+from lean_explore.util.embedding_client import EmbeddingClient
+from lean_explore.util.logging import setup_logging
+from lean_explore.util.openrouter_client import OpenRouterClient
+
+__all__ = ["EmbeddingClient", "OpenRouterClient", "setup_logging"]

--- a/src/lean_explore/util/logging.py
+++ b/src/lean_explore/util/logging.py
@@ -1,0 +1,18 @@
+"""Logging utilities for lean_explore."""
+
+import logging
+import sys
+
+
+def setup_logging(verbose: bool = False) -> None:
+    """Configure logging for lean_explore applications.
+
+    Args:
+        verbose: If True, set level to DEBUG; otherwise INFO.
+    """
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        handlers=[logging.StreamHandler(sys.stdout)],
+    )


### PR DESCRIPTION
## Summary
- Created `util/__init__.py` to export commonly used utilities
- Extracted `setup_logging` to `util/logging.py` 
- Updated all imports to use `from lean_explore.util import ...`
- Removed duplicate `setup_logging` function from `extract/__main__.py`

## Benefits
- Cleaner imports across the codebase
- Reduced code duplication
- Centralized utility exports