### PR TITLE
Capped mcp version to <1.12.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "openai-agents>=0.0.16",
 
     # MCP Server Components
-    "mcp>=1.9.0",
+    "mcp>=1.9.0,<1.12.3",
 
     # Utilities
     "tqdm>=4.60",


### PR DESCRIPTION
Capped mcp version to <1.12.3 in light of #31 (Note not tested as `make install` also seems to be broken)