### PR TITLE
Add kind field to declaration schema

### DIFF
--- a/src/lean_explore/extract/doc_parser.py
+++ b/src/lean_explore/extract/doc_parser.py
@@ -201,6 +201,7 @@ def _parse_declarations_from_files(
                 declarations.append(
                     Declaration(
                         name=information["name"],
+                        kind=information["kind"],
                         module=module_name,
                         docstring=information.get("doc"),
                         source_text=source_text,
@@ -255,6 +256,7 @@ async def _insert_declarations_batch(
                         insert(DBDeclaration)
                         .values(
                             name=declaration.name,
+                            kind=declaration.kind,
                             module=declaration.module,
                             docstring=declaration.docstring,
                             source_text=declaration.source_text,

--- a/src/lean_explore/extract/types.py
+++ b/src/lean_explore/extract/types.py
@@ -9,6 +9,9 @@ class Declaration(BaseModel):
     name: str
     """Fully qualified Lean name."""
 
+    kind: str
+    """Declaration kind (e.g., 'theorem', 'def', 'structure', 'class')."""
+
     module: str
     """Module name."""
 

--- a/src/lean_explore/models/__init__.py
+++ b/src/lean_explore/models/__init__.py
@@ -3,7 +3,14 @@
 This package contains database models and type definitions for search results.
 """
 
+from lean_explore.models.informal_db import InformalizationCache
 from lean_explore.models.search_db import Base, Declaration
 from lean_explore.models.search_types import SearchResponse, SearchResult
 
-__all__ = ["Base", "Declaration", "SearchResult", "SearchResponse"]
+__all__ = [
+    "Base",
+    "Declaration",
+    "InformalizationCache",
+    "SearchResult",
+    "SearchResponse",
+]

--- a/src/lean_explore/models/search_db.py
+++ b/src/lean_explore/models/search_db.py
@@ -52,6 +52,9 @@ class Declaration(Base):
     name: Mapped[str] = mapped_column(Text, unique=True, index=True, nullable=False)
     """Fully qualified Lean name (e.g., 'Nat.add')."""
 
+    kind: Mapped[str] = mapped_column(Text, index=True, nullable=False)
+    """Declaration kind (e.g., 'theorem', 'def', 'structure', 'class')."""
+
     module: Mapped[str] = mapped_column(Text, index=True, nullable=False)
     """Module name (e.g., 'Mathlib.Data.List.Basic')."""
 

--- a/src/lean_explore/models/search_types.py
+++ b/src/lean_explore/models/search_types.py
@@ -16,6 +16,9 @@ class SearchResult(BaseModel):
     name: str
     """Fully qualified Lean name (e.g., 'Nat.add')."""
 
+    kind: str
+    """Declaration kind (e.g., 'theorem', 'def', 'structure', 'class')."""
+
     module: str
     """Module name (e.g., 'Mathlib.Data.List.Basic')."""
 

--- a/src/lean_explore/search/engine.py
+++ b/src/lean_explore/search/engine.py
@@ -180,6 +180,7 @@ class SearchEngine:
         return SearchResult(
             id=decl.id,
             name=decl.name,
+            kind=decl.kind,
             module=decl.module,
             docstring=decl.docstring,
             source_text=decl.source_text,


### PR DESCRIPTION
## Summary
Add `kind` field (theorem, def, structure, class, etc.) to declarations for better filtering and search result display.

## Changes
- Add indexed `kind` column to Declaration model
- Extract `kind` from BMP files in doc parser
- Include `kind` in SearchResult responses

## Breaking Change
New non-nullable column requires database recreation or migration.