### PR TITLE
Fix doc-gen4 build by running full Lake pipeline

### DIFF
--- a/src/lean_explore/extract/doc_gen4.py
+++ b/src/lean_explore/extract/doc_gen4.py
@@ -1,0 +1,60 @@
+"""Documentation generation using doc-gen4.
+
+This module provides functionality to run doc-gen4 to generate Lean documentation
+data that can be parsed and processed by the extraction pipeline.
+"""
+
+import logging
+import subprocess
+
+logger = logging.getLogger(__name__)
+
+
+async def run_doc_gen4() -> None:
+    """Run doc-gen4 to generate documentation data.
+
+    This function:
+    1. Cleans the Lake build cache
+    2. Updates Lake dependencies
+    3. Fetches cached build artifacts
+    4. Builds the Lean library
+    5. Generates documentation using doc-gen4
+
+    Each step streams output in real-time.
+
+    Raises:
+        RuntimeError: If any build step fails with a non-zero exit code.
+    """
+    logger.info("Running doc-gen4 to generate documentation...")
+
+    commands = [
+        (["lake", "clean"], "Cleaning Lake build cache"),
+        (["lake", "update"], "Updating Lake dependencies"),
+        (["lake", "exe", "cache", "get"], "Fetching cached build artifacts"),
+        (["lake", "build"], "Building Lean library"),
+        (["lake", "build", "LeanExtract:docs"], "Generating documentation"),
+    ]
+
+    for command, description in commands:
+        logger.info(f"{description}...")
+
+        process = subprocess.Popen(
+            command,
+            cwd="lean",
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+        )
+
+        if process.stdout:
+            for line in process.stdout:
+                print(line, end="", flush=True)
+
+        returncode = process.wait()
+
+        if returncode != 0:
+            logger.error(f"{description} failed with return code {returncode}")
+            raise RuntimeError(f"{description} failed")
+
+    logger.info("doc-gen4 generation complete")


### PR DESCRIPTION
- Extract doc-gen4 logic into separate module (doc_gen4.py)
- Run lake clean, update, cache get, and build before doc-gen4
- Add proper error handling and logging for each build step
- Stream output in real-time for better debugging

This fixes the 'no such file or directory' errors by ensuring all dependencies are built and cached artifacts are fetched before attempting to generate documentation.