### PR TITLE
Refactor package_config into separate modules

### DIFF
--- a/src/lean_explore/extract/doc_gen4.py
+++ b/src/lean_explore/extract/doc_gen4.py
@@ -11,9 +11,9 @@ import subprocess
 from pathlib import Path
 
 from lean_explore.extract.github import extract_lean_version
-from lean_explore.extract.package_config import (
-    PACKAGE_REGISTRY,
-    PackageConfig,
+from lean_explore.extract.package_config import PackageConfig
+from lean_explore.extract.package_registry import PACKAGE_REGISTRY
+from lean_explore.extract.package_utils import (
     get_extraction_order,
     get_package_toolchain,
     update_lakefile_docgen_version,

--- a/src/lean_explore/extract/doc_parser.py
+++ b/src/lean_explore/extract/doc_parser.py
@@ -43,7 +43,7 @@ def _build_package_cache(
     Returns:
         Dictionary mapping lowercase package names to their directory paths.
     """
-    from lean_explore.extract.package_config import get_extraction_order
+    from lean_explore.extract.package_utils import get_extraction_order
 
     lean_root = Path(lean_root)
     cache = {}
@@ -340,10 +340,8 @@ async def extract_declarations(engine: AsyncEngine, batch_size: int = 1000) -> N
         engine: SQLAlchemy async engine for database connection.
         batch_size: Number of declarations to insert per database transaction.
     """
-    from lean_explore.extract.package_config import (
-        PACKAGE_REGISTRY,
-        get_extraction_order,
-    )
+    from lean_explore.extract.package_registry import PACKAGE_REGISTRY
+    from lean_explore.extract.package_utils import get_extraction_order
 
     lean_root = Path("lean")
     all_declarations = []

--- a/src/lean_explore/extract/package_config.py
+++ b/src/lean_explore/extract/package_config.py
@@ -1,16 +1,12 @@
 """Package configuration for Lean extraction.
 
-This module defines the registry of Lean packages to extract, including their
-GitHub URLs, module prefixes, and version strategies.
+This module defines the configuration dataclass and version strategy enum
+for Lean packages to extract.
 """
 
-import logging
-import re
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
-
-logger = logging.getLogger(__name__)
 
 
 class VersionStrategy(Enum):
@@ -61,142 +57,3 @@ class PackageConfig:
             module_name == prefix or module_name.startswith(prefix + ".")
             for prefix in self.module_prefixes
         )
-
-
-# =============================================================================
-# Package Registry
-# =============================================================================
-
-PACKAGE_REGISTRY: dict[str, PackageConfig] = {
-    "mathlib": PackageConfig(
-        name="mathlib",
-        git_url="https://github.com/leanprover-community/mathlib4",
-        module_prefixes=["Mathlib", "Batteries", "Init", "Lean", "Std"],
-        version_strategy=VersionStrategy.LATEST,
-        depends_on=[],
-        extract_core=True,
-    ),
-    "physlean": PackageConfig(
-        name="physlean",
-        git_url="https://github.com/HEPLean/PhysLean",
-        module_prefixes=["PhysLean"],
-        version_strategy=VersionStrategy.TAGGED,
-        depends_on=["mathlib"],
-    ),
-    "flt": PackageConfig(
-        name="flt",
-        git_url="https://github.com/ImperialCollegeLondon/FLT",
-        module_prefixes=["FLT"],
-        version_strategy=VersionStrategy.LATEST,
-        depends_on=["mathlib"],
-    ),
-    "formal-conjectures": PackageConfig(
-        name="formal-conjectures",
-        git_url="https://github.com/google-deepmind/formal-conjectures",
-        module_prefixes=["FormalConjectures", "FormalConjecturesForMathlib"],
-        version_strategy=VersionStrategy.LATEST,
-        depends_on=["mathlib"],
-    ),
-    "cslib": PackageConfig(
-        name="cslib",
-        git_url="https://github.com/leanprover/cslib",
-        module_prefixes=["Cslib"],
-        version_strategy=VersionStrategy.LATEST,
-        depends_on=["mathlib"],
-    ),
-}
-
-
-# =============================================================================
-# Query Functions
-# =============================================================================
-
-
-def get_package_for_module(module_name: str) -> str | None:
-    """Determine which package a module belongs to.
-
-    Args:
-        module_name: Fully qualified module name (e.g., 'Mathlib.Data.List.Basic')
-
-    Returns:
-        Package name or None if not recognized.
-    """
-    for package_name, config in PACKAGE_REGISTRY.items():
-        if config.should_include_module(module_name):
-            return package_name
-    return None
-
-
-def get_extraction_order() -> list[str]:
-    """Get packages in dependency order for extraction.
-
-    Returns packages ordered so dependencies come before dependents.
-    """
-    result: list[str] = []
-    visited: set[str] = set()
-
-    def visit(name: str) -> None:
-        if name in visited:
-            return
-        visited.add(name)
-        config = PACKAGE_REGISTRY.get(name)
-        if config:
-            for dep in config.depends_on:
-                visit(dep)
-            result.append(name)
-
-    for name in PACKAGE_REGISTRY:
-        visit(name)
-
-    return result
-
-
-def get_package_toolchain(package_config: PackageConfig) -> tuple[str, str]:
-    """Get the toolchain and ref for a package based on its version strategy.
-
-    Args:
-        package_config: Package configuration
-
-    Returns:
-        Tuple of (lean_toolchain, git_ref) where git_ref is the branch/tag to use.
-    """
-    from lean_explore.extract.github import fetch_latest_tag, fetch_lean_toolchain
-
-    if package_config.version_strategy == VersionStrategy.LATEST:
-        for branch in ["main", "master"]:
-            try:
-                toolchain = fetch_lean_toolchain(package_config.git_url, branch)
-                return toolchain, branch
-            except RuntimeError:
-                continue
-        raise RuntimeError(
-            f"Could not fetch toolchain from main or master for {package_config.name}"
-        )
-    else:
-        latest_tag = fetch_latest_tag(package_config.git_url)
-        toolchain = fetch_lean_toolchain(package_config.git_url, latest_tag)
-        return toolchain, latest_tag
-
-
-def update_lakefile_docgen_version(lakefile_path: Path, lean_version: str) -> None:
-    """Update the doc-gen4 version in a lakefile to match the Lean version.
-
-    Args:
-        lakefile_path: Path to lakefile.lean
-        lean_version: Lean version like 'v4.27.0'
-    """
-    content = lakefile_path.read_text()
-
-    pattern = (
-        r'require «doc-gen4» from git\s+'
-        r'"https://github\.com/leanprover/doc-gen4"(?:\s+@\s+"[^"]*")?'
-    )
-    replacement = (
-        f'require «doc-gen4» from git\n'
-        f'  "https://github.com/leanprover/doc-gen4" @ "{lean_version}"'
-    )
-    new_content = re.sub(pattern, replacement, content)
-
-    if new_content != content:
-        lakefile_path.write_text(new_content)
-        logger.info(f"Updated doc-gen4 version to {lean_version} in {lakefile_path}")

--- a/src/lean_explore/extract/package_registry.py
+++ b/src/lean_explore/extract/package_registry.py
@@ -1,0 +1,45 @@
+"""Package registry for Lean extraction.
+
+This module contains the registry of Lean packages available for extraction.
+"""
+
+from lean_explore.extract.package_config import PackageConfig, VersionStrategy
+
+PACKAGE_REGISTRY: dict[str, PackageConfig] = {
+    "mathlib": PackageConfig(
+        name="mathlib",
+        git_url="https://github.com/leanprover-community/mathlib4",
+        module_prefixes=["Mathlib", "Batteries", "Init", "Lean", "Std"],
+        version_strategy=VersionStrategy.LATEST,
+        depends_on=[],
+        extract_core=True,
+    ),
+    "physlean": PackageConfig(
+        name="physlean",
+        git_url="https://github.com/HEPLean/PhysLean",
+        module_prefixes=["PhysLean"],
+        version_strategy=VersionStrategy.TAGGED,
+        depends_on=["mathlib"],
+    ),
+    "flt": PackageConfig(
+        name="flt",
+        git_url="https://github.com/ImperialCollegeLondon/FLT",
+        module_prefixes=["FLT"],
+        version_strategy=VersionStrategy.LATEST,
+        depends_on=["mathlib"],
+    ),
+    "formal-conjectures": PackageConfig(
+        name="formal-conjectures",
+        git_url="https://github.com/google-deepmind/formal-conjectures",
+        module_prefixes=["FormalConjectures", "FormalConjecturesForMathlib"],
+        version_strategy=VersionStrategy.LATEST,
+        depends_on=["mathlib"],
+    ),
+    "cslib": PackageConfig(
+        name="cslib",
+        git_url="https://github.com/leanprover/cslib",
+        module_prefixes=["Cslib"],
+        version_strategy=VersionStrategy.LATEST,
+        depends_on=["mathlib"],
+    ),
+}

--- a/src/lean_explore/extract/package_utils.py
+++ b/src/lean_explore/extract/package_utils.py
@@ -1,0 +1,105 @@
+"""Utility functions for package configuration.
+
+This module provides helper functions for working with the package registry,
+including dependency ordering, toolchain resolution, and lakefile manipulation.
+"""
+
+import logging
+import re
+from pathlib import Path
+
+from lean_explore.extract.package_config import PackageConfig, VersionStrategy
+from lean_explore.extract.package_registry import PACKAGE_REGISTRY
+
+logger = logging.getLogger(__name__)
+
+
+def get_package_for_module(module_name: str) -> str | None:
+    """Determine which package a module belongs to.
+
+    Args:
+        module_name: Fully qualified module name (e.g., 'Mathlib.Data.List.Basic')
+
+    Returns:
+        Package name or None if not recognized.
+    """
+    for package_name, configuration in PACKAGE_REGISTRY.items():
+        if configuration.should_include_module(module_name):
+            return package_name
+    return None
+
+
+def get_extraction_order() -> list[str]:
+    """Get packages in dependency order for extraction.
+
+    Returns packages ordered so dependencies come before dependents.
+    """
+    result: list[str] = []
+    visited: set[str] = set()
+
+    def visit(name: str) -> None:
+        if name in visited:
+            return
+        visited.add(name)
+        configuration = PACKAGE_REGISTRY.get(name)
+        if configuration:
+            for dep in configuration.depends_on:
+                visit(dep)
+            result.append(name)
+
+    for name in PACKAGE_REGISTRY:
+        visit(name)
+
+    return result
+
+
+def get_package_toolchain(package_configuration: PackageConfig) -> tuple[str, str]:
+    """Get the toolchain and ref for a package based on its version strategy.
+
+    Args:
+        package_configuration: Package configuration
+
+    Returns:
+        Tuple of (lean_toolchain, git_ref) where git_ref is the branch/tag to use.
+    """
+    from lean_explore.extract.github import fetch_latest_tag, fetch_lean_toolchain
+
+    if package_configuration.version_strategy == VersionStrategy.LATEST:
+        for branch in ["main", "master"]:
+            try:
+                toolchain = fetch_lean_toolchain(package_configuration.git_url, branch)
+                return toolchain, branch
+            except RuntimeError:
+                continue
+        raise RuntimeError(
+            f"Could not fetch toolchain from main or master for "
+            f"{package_configuration.name}"
+        )
+    else:
+        latest_tag = fetch_latest_tag(package_configuration.git_url)
+        toolchain = fetch_lean_toolchain(package_configuration.git_url, latest_tag)
+        return toolchain, latest_tag
+
+
+def update_lakefile_docgen_version(lakefile_path: Path, lean_version: str) -> None:
+    """Update the doc-gen4 version in a lakefile to match the Lean version.
+
+    Args:
+        lakefile_path: Path to lakefile.lean
+        lean_version: Lean version like 'v4.27.0'
+    """
+    content = lakefile_path.read_text()
+
+    pattern = (
+        r'require «doc-gen4» from git\s+'
+        r'"https://github\.com/leanprover/doc-gen4"(?:\s+@\s+"[^"]*")?'
+    )
+    replacement = (
+        f'require «doc-gen4» from git\n'
+        f'  "https://github.com/leanprover/doc-gen4" @ "{lean_version}"'
+    )
+    new_content = re.sub(pattern, replacement, content)
+
+    if new_content != content:
+        lakefile_path.write_text(new_content)
+        logger.info(f"Updated doc-gen4 version to {lean_version} in {lakefile_path}")


### PR DESCRIPTION
## Summary
- Extract `PACKAGE_REGISTRY` to `package_registry.py`
- Move helper functions to `package_utils.py`
- Keep only `VersionStrategy` and `PackageConfig` in `package_config.py`
- Update imports in `doc_gen4.py` and `doc_parser.py`