### PR TITLE
Replace Any types with TypedDict definitions

### DIFF
--- a/src/lean_explore/cli/data_commands.py
+++ b/src/lean_explore/cli/data_commands.py
@@ -8,7 +8,7 @@ FAISS index, etc.) from remote storage using Pooch for checksums and caching.
 
 import logging
 import shutil
-from typing import Any
+from typing import TypedDict
 
 import pooch
 import requests
@@ -16,6 +16,28 @@ import typer
 from rich.console import Console
 
 from lean_explore.config import Config
+
+
+class ManifestFileEntry(TypedDict):
+    """A file entry in the manifest's toolchain version."""
+
+    remote_name: str
+    local_name: str
+    sha256: str
+
+
+class ToolchainVersionInfo(TypedDict):
+    """Version information for a specific toolchain in the manifest."""
+
+    assets_base_path_r2: str
+    files: list[ManifestFileEntry]
+
+
+class Manifest(TypedDict):
+    """Remote data manifest structure."""
+
+    default_toolchain: str
+    toolchains: dict[str, ToolchainVersionInfo]
 
 logger = logging.getLogger(__name__)
 
@@ -32,7 +54,7 @@ def _get_console() -> Console:
     return Console()
 
 
-def _fetch_manifest() -> dict[str, Any] | None:
+def _fetch_manifest() -> Manifest | None:
     """Fetches the remote data manifest.
 
     Returns:
@@ -49,7 +71,7 @@ def _fetch_manifest() -> dict[str, Any] | None:
         return None
 
 
-def _resolve_version(manifest: dict[str, Any], version: str | None) -> str:
+def _resolve_version(manifest: Manifest, version: str | None) -> str:
     """Resolves the version string to an actual toolchain version.
 
     Args:
@@ -70,7 +92,7 @@ def _resolve_version(manifest: dict[str, Any], version: str | None) -> str:
     return version
 
 
-def _build_file_registry(version_info: dict[str, Any]) -> dict[str, str]:
+def _build_file_registry(version_info: ToolchainVersionInfo) -> dict[str, str]:
     """Builds a Pooch registry from version info.
 
     Args:

--- a/src/lean_explore/mcp/tools.py
+++ b/src/lean_explore/mcp/tools.py
@@ -2,12 +2,34 @@
 
 import asyncio
 import logging
-from typing import Any
+from typing import TypedDict
 
 from mcp.server.fastmcp import Context as MCPContext
 
 from lean_explore.mcp.app import AppContext, BackendServiceType, mcp_app
 from lean_explore.models import SearchResponse, SearchResult
+
+
+class SearchResultDict(TypedDict, total=False):
+    """Serialized SearchResult for MCP tool responses."""
+
+    id: int
+    name: str
+    module: str
+    docstring: str | None
+    source_text: str
+    source_link: str
+    dependencies: str | None
+    informalization: str | None
+
+
+class SearchResponseDict(TypedDict, total=False):
+    """Serialized SearchResponse for MCP tool responses."""
+
+    query: str
+    results: list[SearchResultDict]
+    count: int
+    processing_time_ms: int | None
 
 logger = logging.getLogger(__name__)
 
@@ -38,7 +60,7 @@ async def search(
     query: str,
     limit: int = 10,
     rerank_top: int | None = 50,
-) -> dict[str, Any]:
+) -> SearchResponseDict:
     """Searches Lean declarations by a query string.
 
     Args:
@@ -79,7 +101,7 @@ async def search(
 async def get_by_id(
     ctx: MCPContext,
     declaration_id: int,
-) -> dict[str, Any] | None:
+) -> SearchResultDict | None:
     """Retrieves a specific declaration by its unique identifier.
 
     Args:


### PR DESCRIPTION
## Summary
- Add `ManifestFileEntry`, `ToolchainVersionInfo`, `Manifest` TypedDicts in `data_commands.py`
- Add `SearchResultDict`, `SearchResponseDict` TypedDicts in `mcp/tools.py`
- Update function signatures to use specific types instead of `dict[str, Any]`

## Test plan
- [x] All 58 existing tests pass
- [x] Ruff linter passes