### PR TITLE
Fix async search command not being awaited

### DIFF
--- a/src/lean_explore/cli/main.py
+++ b/src/lean_explore/cli/main.py
@@ -4,6 +4,7 @@ Provides commands to search for Lean declarations via the remote API,
 interact with AI agents, and manage local data.
 """
 
+import asyncio
 import logging
 import os
 import subprocess
@@ -50,13 +51,18 @@ def _get_console(use_stderr: bool = False) -> Console:
 
 
 @app.command("search")
-async def search_command(
+def search_command(
     query_string: str = typer.Argument(..., help="The search query string."),
     limit: int = typer.Option(
         5, "--limit", "-n", help="Number of search results to display."
     ),
 ):
     """Search for Lean declarations using the Lean Explore API."""
+    asyncio.run(_search_async(query_string, limit))
+
+
+async def _search_async(query_string: str, limit: int) -> None:
+    """Async implementation of search command."""
     console = _get_console()
     error_console = _get_console(use_stderr=True)
 


### PR DESCRIPTION
## Summary
Typer doesn't automatically handle async command functions. The `search` command was defined as `async def` but never awaited, causing a RuntimeWarning.

Fix: Wrap the async logic in a helper function and use `asyncio.run()` in the sync command handler.

## Test plan
- [x] `lean-explore search "test"` now executes properly (shows API key error as expected, not coroutine warning)
- [x] Ruff passes