### PR TITLE
Fix CHANGELOG accuracy for 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,24 +15,19 @@ Complete architectural rewrite. The external interface remains similar, but the
 entire codebase has been rebuilt from scratch with a new data model, search
 algorithm, and local-first architecture.
 
-### Architecture
-- **Local-first design**: Search runs entirely on your machine using downloaded data
-- **Hybrid search**: Combines BM25 lexical search with FAISS semantic vector search
-- **Cross-encoder reranking**: Uses sentence transformers for result quality
+### Changed
+- **Hybrid search**: Combines BM25 lexical search with FAISS semantic vector search (previously FAISS-only)
+- **Cross-encoder reranking**: Uses sentence transformers for improved result quality
 - **Nightly updates**: Data toolchain fetched from remote manifest with SHA256 verification
-
-### New Features
-- `lean-explore data fetch` / `lean-explore data clean` CLI commands
-- MCP (Model Context Protocol) server for AI assistant integration
-- Support for 9 indexed packages: Batteries, CSLib, FLT, FormalConjectures, Init, Lean, Mathlib, PhysLean, Std
-- LLM-generated natural language descriptions (informalizations) for declarations
-- Extraction pipeline for processing doc-gen4 output
-
-### Breaking Changes
+- **Expanded package support**: Now indexes 9 packages (Batteries, CSLib, FLT, FormalConjectures, Init, Lean, Mathlib, PhysLean, Std)
 - New data model: `Declaration` replaces `StatementGroup`
 - New field names: `name`, `module`, `source_text`, `source_link`, `informalization`
 - Simplified API: `SearchEngine`, `Service`, `SearchResult`, `SearchResponse`
-- Remote API endpoints changed: `/declarations/{id}` replaces `/statement_groups/{id}`
+- Remote API endpoints: `/declarations/{id}` replaces `/statement_groups/{id}`
+
+### Added
+- LLM-generated natural language descriptions (informalizations) for declarations
+- New extraction pipeline for processing doc-gen4 output
 
 ## [0.3.0] - 2025-06-09
 


### PR DESCRIPTION
MCP server and data CLI commands existed in 0.3.0, not new features. Reorganized to properly distinguish Changed vs Added.