### PR TITLE
Pre-build BM25 indices in extraction pipeline

### DIFF
--- a/src/lean_explore/config.py
+++ b/src/lean_explore/config.py
@@ -93,6 +93,15 @@ class Config:
     )
     """Path to FAISS ID mapping file in cache."""
 
+    BM25_SPACED_PATH: pathlib.Path = ACTIVE_CACHE_PATH / "bm25_name_spaced"
+    """Path to BM25 spaced tokenization index directory in cache."""
+
+    BM25_RAW_PATH: pathlib.Path = ACTIVE_CACHE_PATH / "bm25_name_raw"
+    """Path to BM25 raw tokenization index directory in cache."""
+
+    BM25_IDS_MAP_PATH: pathlib.Path = ACTIVE_CACHE_PATH / "bm25_ids_map.json"
+    """Path to BM25 ID mapping file in cache."""
+
     DATABASE_URL: str = f"sqlite+aiosqlite:///{DATABASE_PATH}"
     """Async SQLAlchemy database URL for SQLite (used by search engine)."""
 

--- a/src/lean_explore/extract/__main__.py
+++ b/src/lean_explore/extract/__main__.py
@@ -99,17 +99,18 @@ async def _run_embeddings_step(
 
 
 async def _run_index_step(engine: AsyncEngine, extraction_path: Path) -> None:
-    """Build FAISS indices from embeddings.
+    """Build search indices (FAISS and BM25).
 
     Args:
         engine: SQLAlchemy async engine instance.
         extraction_path: Directory to save indices (same as database location).
     """
-    from lean_explore.extract.index import build_faiss_indices
+    from lean_explore.extract.index import build_bm25_indices, build_faiss_indices
 
-    logger.info("Step 4: Building FAISS indices...")
+    logger.info("Step 4: Building search indices...")
     await build_faiss_indices(engine, output_directory=extraction_path)
-    logger.info("FAISS index building complete")
+    await build_bm25_indices(engine, output_directory=extraction_path)
+    logger.info("Index building complete")
 
 
 async def run_pipeline(

--- a/tests/cli/main_test.py
+++ b/tests/cli/main_test.py
@@ -9,7 +9,7 @@ import pytest
 import typer
 from typer.testing import CliRunner
 
-from lean_explore.cli.main import _get_console, app, search_command
+from lean_explore.cli.main import _get_console, _search_async, app
 from lean_explore.models import SearchResponse, SearchResult
 
 runner = CliRunner()
@@ -64,8 +64,8 @@ class TestSearchCommand:
         with patch(
             "lean_explore.cli.main.ApiClient", return_value=mock_api_client
         ), patch("lean_explore.cli.main.display_search_results"):
-            # Test the async function directly
-            await search_command(query_string="test query", limit=5)
+            # Test the async implementation directly
+            await _search_async(query_string="test query", limit=5)
             mock_api_client.search.assert_called_once_with(
                 query="test query", limit=5
             )
@@ -75,7 +75,7 @@ class TestSearchCommand:
         with patch(
             "lean_explore.cli.main.ApiClient", return_value=mock_api_client
         ), patch("lean_explore.cli.main.display_search_results"):
-            await search_command(query_string="test query", limit=10)
+            await _search_async(query_string="test query", limit=10)
             mock_api_client.search.assert_called_once_with(
                 query="test query", limit=10
             )
@@ -87,7 +87,7 @@ class TestSearchCommand:
             side_effect=ValueError("API key required"),
         ):
             with pytest.raises(typer.Exit) as exc_info:
-                await search_command(query_string="test query", limit=5)
+                await _search_async(query_string="test query", limit=5)
             assert exc_info.value.exit_code == 1
 
 


### PR DESCRIPTION
Previously, BM25 indices were built from scratch at runtime by loading all 380K+ declaration names from the database. This caused slow MCP server startup (~30s just for BM25 building).

## Changes
- Add `build_bm25_indices()` to extraction pipeline
- Extraction pipeline now builds both FAISS and BM25 indices
- SearchEngine loads pre-built BM25 indices from disk
- Add BM25 index paths to Config

## Impact
MCP server startup is now faster - BM25 indices load instantly instead of being built from scratch.