### PR TITLE
Update API base URL from v1 to v2

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -24,7 +24,7 @@ tags:
     description: Endpoints for retrieving specific declarations by ID.
 
 servers:
-  - url: https://www.leanexplore.com/api/v1
+  - url: https://www.leanexplore.com/api/v2
     description: Production LeanExplore API Server
 
 components:

--- a/src/lean_explore/config.py
+++ b/src/lean_explore/config.py
@@ -208,5 +208,5 @@ class Config:
     R2_ASSETS_BASE_URL: str = "https://pub-48b75babc4664808b15520033423c765.r2.dev"
     """Base URL for Cloudflare R2 asset storage."""
 
-    API_BASE_URL: str = "https://www.leanexplore.com/api/v1"
+    API_BASE_URL: str = "https://www.leanexplore.com/api/v2"
     """Base URL for the LeanExplore remote API service."""


### PR DESCRIPTION
## Summary
- Update API_BASE_URL in config.py to use /api/v2
- Update openapi.yaml server URL to /api/v2

Part of the lean-explore 1.0.0 release with the new API version.