### PR TITLE
Reduce GPU batch size for reranker to fit 8GB VRAM

### DIFF
--- a/src/lean_explore/util/reranker_client.py
+++ b/src/lean_explore/util/reranker_client.py
@@ -164,9 +164,9 @@ class RerankerClient:
         if not documents:
             return RerankerResponse(query=query, scores=[], model=self.model_name)
 
-        # Default batch size: 128 on GPU (can handle it), 32 on CPU
+        # Default batch size: 16 on GPU (fits 8GB VRAM), 32 on CPU
         if batch_size is None:
-            batch_size = 128 if self.device == "cuda" else 32
+            batch_size = 16 if self.device == "cuda" else 32
 
         # For small batches, run synchronously to avoid executor overhead
         if len(documents) <= batch_size:


### PR DESCRIPTION
## Summary
- Reduced default GPU batch_size from 128 to 16 for the reranker
- Fixes CUDA OOM errors on GPUs with 8GB VRAM (like RTX 3070) when reranking 50 documents
- With batch_size=128, all documents were processed in a single forward pass since 50 <= 128

🤖 Generated with [Claude Code](https://claude.com/claude-code)