### PR TITLE
Add [local] optional dependency group and document installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 N/A
 
+## [1.2.1] - 2026-02-04
+
+### Added
+- `[local]` optional dependency group (`pip install lean-explore[local]`) for running the
+  local search backend, which requires `torch` and `sentence-transformers`.
+- Installation section in README documenting the different install options.
+
+## [1.2.0] - 2026-02-02
+
+### Added
+- Per-field MCP tools (`get_source_code`, `get_source_link`, `get_docstring`,
+  `get_description`, `get_module`, `get_dependencies`) replacing the monolithic `get_by_id` tool.
+- Improved MCP tool docstrings with recommended workflow guidance.
+- Retry logic for `lake update` to handle transient network failures.
+- Lean package workspaces tracked in version control.
+
+### Removed
+- `get_by_id` MCP tool (replaced by per-field tools).
+
 ## [1.1.1] - 2026-01-29
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -25,6 +25,27 @@ A search engine for Lean 4 declarations. This project provides tools and resourc
 
 **For full documentation, please visit: [https://www.leanexplore.com/docs](https://www.leanexplore.com/docs)**
 
+## Installation
+
+The base package connects to the remote API and does not require heavy ML dependencies:
+
+```bash
+pip install lean-explore
+```
+
+To run the **local** search backend (which uses on-device embedding and reranking models), install the extra ML dependencies:
+
+```bash
+pip install lean-explore[local]
+```
+
+Then fetch the data files and start the local MCP server:
+
+```bash
+lean-explore data fetch
+lean-explore mcp serve --backend local
+```
+
 The current indexed projects include:
 
 * Batteries

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lean-explore"
-version = "1.2.0"
+version = "1.2.1"
 authors = [
     { name = "Justin Asher", email = "justinchadwickasher@gmail.com" },
 ]
@@ -66,10 +66,15 @@ Repository = "https://github.com/justincasher/lean-explore"
 lean-explore = "lean_explore.cli.main:app"
 
 [project.optional-dependencies]
+local = [
+    "sentence-transformers>=2.2.0",
+    "torch>=2.0.0",
+]
+
 extract = [
     "sentence-transformers>=2.2.0",
-    "networkx>=3.0",
     "torch>=2.0.0",
+    "networkx>=3.0",
 ]
 
 dev = [


### PR DESCRIPTION
## Summary
- Adds a `[local]` optional dependency group (`pip install lean-explore[local]`) containing `torch` and `sentence-transformers`, so users know exactly what to install for the local MCP server backend.
- Adds an Installation section to the README documenting both the base install and the local backend install.
- Backfills the missing `[1.2.0]` changelog entry and adds `[1.2.1]`.
- Bumps version to `1.2.1`.

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)