### PR TITLE
Reduce default informalize concurrency from 100 to 10

### DIFF
--- a/src/lean_explore/extract/__main__.py
+++ b/src/lean_explore/extract/__main__.py
@@ -261,7 +261,7 @@ async def run_pipeline(
 @click.option(
     "--informalize-max-concurrent",
     type=int,
-    default=100,
+    default=10,
     help="Maximum concurrent informalization requests",
 )
 @click.option(

--- a/src/lean_explore/extract/informalize.py
+++ b/src/lean_explore/extract/informalize.py
@@ -572,7 +572,7 @@ async def informalize_declarations(
     *,
     model: str = "google/gemini-3-flash-preview",
     commit_batch_size: int = 1000,
-    max_concurrent: int = 100,
+    max_concurrent: int = 10,
     limit: int | None = None,
 ) -> None:
     """Generate informalizations for declarations missing them.


### PR DESCRIPTION
## Summary
- Reduces default `--informalize-max-concurrent` from 100 to 10 to stay within OpenRouter rate limits (275-450 RPM for Gemini Flash)
- The nightly pipeline has been failing for 11 days due to rate limit exhaustion crashing the informalize step

## Test plan
- [ ] Verify nightly pipeline completes successfully with the lower concurrency

🤖 Generated with [Claude Code](https://claude.com/claude-code)