### PR TITLE
Reduce embedding batch size to prevent GPU OOM

### DIFF
--- a/src/lean_explore/util/embedding_client.py
+++ b/src/lean_explore/util/embedding_client.py
@@ -78,7 +78,7 @@ class EmbeddingClient:
             encode_kwargs = {
                 "show_progress_bar": False,
                 "convert_to_numpy": True,
-                "batch_size": 256,  # Larger batches for GPU utilization
+                "batch_size": 32,
             }
             if is_query:
                 encode_kwargs["prompt_name"] = "query"


### PR DESCRIPTION
## Summary
- Reduce `batch_size` from 256 to 32 in `EmbeddingClient.embed()` to prevent CUDA OOM when the backend GPU is already loaded with models for serving.