### PR TITLE
fix: switch TypedDict import to typing_extensions for py3.11- compatibility

### DIFF
--- a/src/lean_explore/mcp/tools.py
+++ b/src/lean_explore/mcp/tools.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import logging
-from typing import TypedDict
+from typing_extensions import TypedDict
 
 from mcp.server.fastmcp import Context as MCPContext
 


### PR DESCRIPTION
  This is a small compatibility fix. Behavior kept unchanged.