### PR TITLE
Deprecate the full-result MCP search tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ The hosted endpoint allows 30 POST requests per client IP in any 60-second
 window. Protocol initialization and tool-discovery requests count toward the
 limit, and clients sharing a public IP share the same budget.
 
+Agents should begin with the token-efficient `search_summary` tool, then use
+the per-field retrieval tools for the declarations they need. The older
+full-result `search` MCP tool is deprecated and remains only for compatibility.
+
 In Claude Code:
 
 ```text

--- a/docs/data-models.md
+++ b/docs/data-models.md
@@ -55,8 +55,8 @@ Envelope returned by `ApiClient.search()` and `Service.search()`.
 
 ## `SearchResultSummary`
 
-Slim form used by the MCP `search_summary` tool. Contains only enough to let
-a caller decide which ids to drill into.
+Slim form used by the preferred MCP `search_summary` tool. Contains only
+enough to let a caller decide which ids to drill into.
 
 | Field | Type | Description |
 |---|---|---|

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -119,9 +119,11 @@ Any client that accepts a command + args will work. Point it at the
 
 ## The tools
 
-The server registers eight tools. IDs returned from `search` or
-`search_summary` can be passed to the per-field getters to fetch exactly the
-field you need, which keeps token usage low.
+The server registers seven current tools: `search_summary` and six per-field
+getters. It also retains the legacy full-result `search` tool as a deprecated
+compatibility alias. IDs returned from `search_summary` can be passed to the
+per-field getters to fetch exactly the field you need, which keeps token usage
+low.
 
 ### `search_summary`: the preferred starting point
 
@@ -150,19 +152,17 @@ then fetch details for the handful of entries you care about.
 }
 ```
 
-### `search`: full results
+### `search`: deprecated compatibility tool
 
-Same parameters as `search_summary`, but each result includes every field:
-`id`, `name`, `module`, `docstring`, `source_text`, `source_link`,
-`dependencies`, and `informalization`. Use this when you genuinely need all
-fields at once. For large `limit` values, prefer `search_summary` plus the
-per-field getters.
+Do not use this tool in new integrations. It remains registered so existing
+MCP clients do not break. It has the same parameters as `search_summary`, but
+returns every field for every result and can consume substantially more
+context. Use `search_summary` followed by the per-field getters instead.
 
 ### Per-field getters
 
 All six take a single parameter `declaration_id` (integer) and return `null`
-if the id does not exist. The id comes from a prior `search` or
-`search_summary` result.
+if the id does not exist. The id comes from a prior `search_summary` result.
 
 | Tool | Returns |
 |---|---|
@@ -181,8 +181,9 @@ The server's built-in instructions ask models to follow this pattern:
 2. **Fetch only what you need** with the per-field getters (`get_source_code`,
    `get_docstring`, `get_description`, `get_module`, `get_dependencies`,
    `get_source_link`).
-3. **Use `search`** only when you genuinely need all fields for every result
-   at once.
+
+The deprecated `search` tool is excluded from this workflow and exists only
+for backwards compatibility.
 
 This keeps context short while still giving the model access to full source
 code and dependency chains when it matters.

--- a/plugins/lean-explore/README.md
+++ b/plugins/lean-explore/README.md
@@ -7,6 +7,10 @@ search index.
 
 The MCP endpoint is `https://www.leanexplore.com/mcp`.
 
+Agents should use `search_summary` to find declarations, then retrieve only
+the fields they need. The older full-result `search` tool is deprecated and
+retained only for backwards compatibility.
+
 The hosted endpoint allows 30 POST requests per client IP in any 60-second
 window. MCP initialization and tool-discovery requests count toward the same
 limit, and clients sharing a public IP share the budget. Limited requests

--- a/src/lean_explore/mcp/app.py
+++ b/src/lean_explore/mcp/app.py
@@ -77,7 +77,7 @@ mcp_app = FastMCP(
         "'a continuous function on a compact set', 'prime number divisibility'). "
         "You can use either style of query.\n\n"
         "Recommended workflow:\n"
-        "1. Use search_summary to browse results (low token cost).\n"
+        "1. Always use search_summary to browse results (low token cost).\n"
         "2. Use per-field tools to fetch only what you need:\n"
         "   - get_source_code: Lean source code\n"
         "   - get_source_link: GitHub link to source\n"
@@ -85,8 +85,9 @@ mcp_app = FastMCP(
         "   - get_description: natural language description\n"
         "   - get_module: module path in the package\n"
         "   - get_dependencies: declarations this depends on\n"
-        "3. Use search only when you need full details for all results "
-        "at once."
+        "The legacy search tool is deprecated and retained only for backwards "
+        "compatibility. Do not use it in new workflows; use search_summary "
+        "followed by the per-field tools instead."
     ),
     lifespan=app_lifespan,
 )

--- a/src/lean_explore/mcp/tools.py
+++ b/src/lean_explore/mcp/tools.py
@@ -187,7 +187,15 @@ async def _execute_backend_get_by_id(
     return backend.get_by_id(declaration_id=declaration_id)
 
 
-@mcp_app.tool()
+@mcp_app.tool(
+    title="[Deprecated] Search with full results",
+    description=(
+        "DEPRECATED: Use search_summary, then fetch needed fields with the "
+        "per-field tools. This compatibility tool returns every field for every "
+        "match and may consume substantially more context."
+    ),
+    meta={"deprecated": True, "replacement": "search_summary"},
+)
 async def search(
     ctx: MCPContext,
     query: str,
@@ -195,7 +203,10 @@ async def search(
     rerank_top: int | None = 50,
     packages: list[str] | None = None,
 ) -> SearchResponseDict:
-    """Search Lean 4 declarations and return full results including source code.
+    """Deprecated MCP compatibility tool returning full search results.
+
+    Use search_summary followed by the per-field tools for all new workflows.
+    This function remains available so existing MCP clients do not break.
 
     Accepts two kinds of queries:
       - By name: a full or partial Lean declaration name, e.g., "List.map",
@@ -209,10 +220,7 @@ async def search(
     specify which kind of query you are making.
 
     Returns full results including source code, module, dependencies, and
-    informalization for every hit. If you only need names and short
-    descriptions, prefer search_summary to save tokens, then use the
-    per-field tools (get_source_code, get_docstring, get_description,
-    get_module, get_dependencies) for the entries you care about.
+    informalization for every hit.
 
     Args:
         ctx: The MCP context, providing access to the backend service.
@@ -231,7 +239,10 @@ async def search(
     logger.info(
         "MCP Tool 'search' called with query: '%s', limit: %d, "
         "rerank_top: %s, packages: %s",
-        query, limit, rerank_top, packages,
+        query,
+        limit,
+        rerank_top,
+        packages,
     )
 
     response = await _execute_backend_search(
@@ -285,7 +296,10 @@ async def search_summary(
     logger.info(
         "MCP Tool 'search_summary' called with query: '%s', limit: %d, "
         "rerank_top: %s, packages: %s",
-        query, limit, rerank_top, packages,
+        query,
+        limit,
+        rerank_top,
+        packages,
     )
 
     response = await _execute_backend_search(
@@ -321,11 +335,11 @@ async def get_source_code(
     Returns the declaration name and its Lean 4 source code. Use this after
     calling search_summary to inspect the actual implementation.
 
-    The id values come from the search or search_summary result lists.
+    The id values come from the search_summary result list.
 
     Args:
         ctx: The MCP context, providing access to the backend service.
-        declaration_id: The numeric id from a search or search_summary result.
+        declaration_id: The numeric id from a search_summary result.
 
     Returns:
         A dictionary with id, name, and source_text, or None if the id
@@ -357,11 +371,11 @@ async def get_source_link(
     Returns the declaration name and a URL to the source code on GitHub.
     Use this when you need to reference or link to the original source.
 
-    The id values come from the search or search_summary result lists.
+    The id values come from the search_summary result list.
 
     Args:
         ctx: The MCP context, providing access to the backend service.
-        declaration_id: The numeric id from a search or search_summary result.
+        declaration_id: The numeric id from a search_summary result.
 
     Returns:
         A dictionary with id, name, and source_link, or None if the id
@@ -394,11 +408,11 @@ async def get_docstring(
     source code. Use this to check what documentation exists without
     fetching the full source code.
 
-    The id values come from the search or search_summary result lists.
+    The id values come from the search_summary result list.
 
     Args:
         ctx: The MCP context, providing access to the backend service.
-        declaration_id: The numeric id from a search or search_summary result.
+        declaration_id: The numeric id from a search_summary result.
 
     Returns:
         A dictionary with id, name, and docstring, or None if the id
@@ -430,11 +444,11 @@ async def get_description(
     Returns the declaration name and its informalization, an AI-generated
     plain-English explanation of what the declaration states or does.
 
-    The id values come from the search or search_summary result lists.
+    The id values come from the search_summary result list.
 
     Args:
         ctx: The MCP context, providing access to the backend service.
-        declaration_id: The numeric id from a search or search_summary result.
+        declaration_id: The numeric id from a search_summary result.
 
     Returns:
         A dictionary with id, name, and informalization, or None if the id
@@ -467,20 +481,18 @@ async def get_module(
     (e.g., 'Mathlib.Data.List.Basic'). Use this to find where a
     declaration lives in the package structure.
 
-    The id values come from the search or search_summary result lists.
+    The id values come from the search_summary result list.
 
     Args:
         ctx: The MCP context, providing access to the backend service.
-        declaration_id: The numeric id from a search or search_summary result.
+        declaration_id: The numeric id from a search_summary result.
 
     Returns:
         A dictionary with id, name, and module, or None if the id does
         not exist.
     """
     backend = await _get_backend_from_context(ctx)
-    logger.info(
-        "MCP Tool 'get_module' called for declaration_id: %d", declaration_id
-    )
+    logger.info("MCP Tool 'get_module' called for declaration_id: %d", declaration_id)
 
     result = await _execute_backend_get_by_id(backend, declaration_id)
     if result is None:
@@ -504,11 +516,11 @@ async def get_dependencies(
     names that this declaration depends on. Use this to understand what
     a declaration builds upon.
 
-    The id values come from the search or search_summary result lists.
+    The id values come from the search_summary result list.
 
     Args:
         ctx: The MCP context, providing access to the backend service.
-        declaration_id: The numeric id from a search or search_summary result.
+        declaration_id: The numeric id from a search_summary result.
 
     Returns:
         A dictionary with id, name, and dependencies, or None if the id

--- a/tests/mcp/tools_test.py
+++ b/tests/mcp/tools_test.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from lean_explore.mcp.app import mcp_app
 from lean_explore.mcp.tools import (
     _get_backend_from_context,
     get_dependencies,
@@ -100,7 +101,16 @@ def _make_mock_context(backend: MagicMock) -> MagicMock:
 
 
 class TestSearchTool:
-    """Tests for the search MCP tool (full results)."""
+    """Tests for the deprecated search MCP compatibility tool."""
+
+    async def test_search_is_advertised_as_deprecated(self):
+        """Ensure MCP clients are explicitly directed to search_summary."""
+        registered_tools = {tool.name: tool for tool in await mcp_app.list_tools()}
+        tool = registered_tools["search"]
+
+        assert tool.title == "[Deprecated] Search with full results"
+        assert tool.description.startswith("DEPRECATED: Use search_summary")
+        assert tool.meta == {"deprecated": True, "replacement": "search_summary"}
 
     @pytest.fixture
     def mock_context_with_backend(self):


### PR DESCRIPTION
## Summary

- retain the MCP `search` tool so existing clients keep working
- advertise it as deprecated in its title, description, and tool metadata, with `search_summary` as its replacement
- instruct agents to always use `search_summary` followed by per-field retrieval tools
- update the package, plugin, MCP, and data-model documentation
- add coverage for the tool metadata exposed through MCP discovery

The Python `ApiClient.search()` method and CLI `lean-explore search` command are unchanged. This deprecates only the token-heavy MCP tool.

## Verification

- `ruff check src/lean_explore/mcp/app.py src/lean_explore/mcp/tools.py tests/mcp/tools_test.py`
- `pytest tests/mcp -q` (67 passed)

## Rollout

Merge this PR before the companion lean-explore-app documentation PR. The app deployment resets the sibling `lean-explore` checkout to `origin/main`, so that deployment will pick up this server-tool change.