### PR TITLE
Prepare public MCP directory submission and 1.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 N/A
 
+## [1.3.0] - 2026-08-02
+
+### Added
+- Public hosted MCP plugin configuration for Claude Code and Codex.
+- Read-only safety annotations on every MCP tool for plugin-directory review.
+
+### Changed
+- The remote API, CLI, and hosted MCP server no longer require an account or API key.
+- MCP agents are directed to use `search_summary` followed by per-field retrieval tools.
+
+### Deprecated
+- API-key arguments remain accepted but are ignored for backwards compatibility.
+- The full-result MCP `search` tool remains available for backwards compatibility;
+  new integrations should use `search_summary`.
+
 ## [1.2.1] - 2026-02-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ limit, and clients sharing a public IP share the same budget.
 Agents should begin with the token-efficient `search_summary` tool, then use
 the per-field retrieval tools for the declarations they need. The older
 full-result `search` MCP tool is deprecated and remains only for compatibility.
+All LeanExplore MCP tools are read-only and cannot modify Lean packages or
+external systems.
 
 In Claude Code:
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -125,6 +125,10 @@ compatibility alias. IDs returned from `search_summary` can be passed to the
 per-field getters to fetch exactly the field you need, which keeps token usage
 low.
 
+All tools are annotated as read-only, non-destructive, and idempotent. They
+operate only on LeanExplore's indexed corpus and cannot modify Lean packages or
+external systems.
+
 ### `search_summary`: the preferred starting point
 
 Returns only `id`, `name`, and a short description per hit. Use this first,

--- a/plugins/lean-explore/README.md
+++ b/plugins/lean-explore/README.md
@@ -11,6 +11,9 @@ Agents should use `search_summary` to find declarations, then retrieve only
 the fields they need. The older full-result `search` tool is deprecated and
 retained only for backwards compatibility.
 
+All tools are read-only. They search or retrieve records from LeanExplore's
+indexed corpus and cannot modify Lean packages or external systems.
+
 The hosted endpoint allows 30 POST requests per client IP in any 60-second
 window. MCP initialization and tool-discovery requests count toward the same
 limit, and clients sharing a public IP share the budget. Limited requests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lean-explore"
-version = "1.2.1"
+version = "1.3.0"
 authors = [
     { name = "Justin Asher", email = "justinchadwickasher@gmail.com" },
 ]

--- a/src/lean_explore/mcp/tools.py
+++ b/src/lean_explore/mcp/tools.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 
 from mcp.server.fastmcp import Context as MCPContext
+from mcp.types import ToolAnnotations
 from typing_extensions import TypedDict
 
 from lean_explore.mcp.app import AppContext, BackendServiceType, mcp_app
@@ -12,6 +13,13 @@ from lean_explore.models.search_types import (
     SearchResultSummary,
     SearchSummaryResponse,
     extract_bold_description,
+)
+
+READ_ONLY_TOOL_ANNOTATIONS = ToolAnnotations(
+    readOnlyHint=True,
+    destructiveHint=False,
+    idempotentHint=True,
+    openWorldHint=False,
 )
 
 
@@ -194,6 +202,7 @@ async def _execute_backend_get_by_id(
         "per-field tools. This compatibility tool returns every field for every "
         "match and may consume substantially more context."
     ),
+    annotations=READ_ONLY_TOOL_ANNOTATIONS,
     meta={"deprecated": True, "replacement": "search_summary"},
 )
 async def search(
@@ -252,7 +261,7 @@ async def search(
     return response.model_dump(exclude_none=True)
 
 
-@mcp_app.tool()
+@mcp_app.tool(annotations=READ_ONLY_TOOL_ANNOTATIONS)
 async def search_summary(
     ctx: MCPContext,
     query: str,
@@ -325,7 +334,7 @@ async def search_summary(
     return summary_response.model_dump(exclude_none=True)
 
 
-@mcp_app.tool()
+@mcp_app.tool(annotations=READ_ONLY_TOOL_ANNOTATIONS)
 async def get_source_code(
     ctx: MCPContext,
     declaration_id: int,
@@ -361,7 +370,7 @@ async def get_source_code(
     )
 
 
-@mcp_app.tool()
+@mcp_app.tool(annotations=READ_ONLY_TOOL_ANNOTATIONS)
 async def get_source_link(
     ctx: MCPContext,
     declaration_id: int,
@@ -397,7 +406,7 @@ async def get_source_link(
     )
 
 
-@mcp_app.tool()
+@mcp_app.tool(annotations=READ_ONLY_TOOL_ANNOTATIONS)
 async def get_docstring(
     ctx: MCPContext,
     declaration_id: int,
@@ -434,7 +443,7 @@ async def get_docstring(
     )
 
 
-@mcp_app.tool()
+@mcp_app.tool(annotations=READ_ONLY_TOOL_ANNOTATIONS)
 async def get_description(
     ctx: MCPContext,
     declaration_id: int,
@@ -470,7 +479,7 @@ async def get_description(
     )
 
 
-@mcp_app.tool()
+@mcp_app.tool(annotations=READ_ONLY_TOOL_ANNOTATIONS)
 async def get_module(
     ctx: MCPContext,
     declaration_id: int,
@@ -505,7 +514,7 @@ async def get_module(
     )
 
 
-@mcp_app.tool()
+@mcp_app.tool(annotations=READ_ONLY_TOOL_ANNOTATIONS)
 async def get_dependencies(
     ctx: MCPContext,
     declaration_id: int,

--- a/tests/mcp/tools_test.py
+++ b/tests/mcp/tools_test.py
@@ -112,6 +112,18 @@ class TestSearchTool:
         assert tool.description.startswith("DEPRECATED: Use search_summary")
         assert tool.meta == {"deprecated": True, "replacement": "search_summary"}
 
+    async def test_all_tools_are_annotated_as_read_only(self):
+        """Expose accurate safety hints required by plugin directories."""
+        registered_tools = await mcp_app.list_tools()
+
+        assert len(registered_tools) == 8
+        for tool in registered_tools:
+            assert tool.annotations is not None
+            assert tool.annotations.readOnlyHint is True
+            assert tool.annotations.destructiveHint is False
+            assert tool.annotations.idempotentHint is True
+            assert tool.annotations.openWorldHint is False
+
     @pytest.fixture
     def mock_context_with_backend(self):
         """Create a mock MCP context with a backend service."""


### PR DESCRIPTION
## Summary

- annotate all eight MCP tools as read-only, non-destructive, idempotent, and closed-world
- preserve the deprecation metadata on the legacy full-result `search` tool
- document that LeanExplore tools cannot modify Lean packages or external systems
- test the annotations exposed through MCP tool discovery
- bump the package to `1.3.0` and document the authless API/plugin release

OpenAI plugin review asks for `readOnlyHint`, `openWorldHint`, and `destructiveHint` on every tool. Anthropic directory review requires every tool to include `readOnlyHint` or `destructiveHint`. PyPI already has `1.2.1`, so the version bump is required to publish the merged authless client.

## Verification

- `ruff check src/lean_explore/mcp/tools.py tests/mcp/tools_test.py`
- `pytest tests/mcp -q` (68 passed)
- `python -m build --outdir /tmp/lean-explore-1.3.0-dist`

## Rollout

Merge this PR first, then the companion lean-explore-app PR so its deployment picks up the updated sibling package from `origin/main`. Publish `lean-explore==1.3.0` to PyPI after deployment.