### PR TITLE
Add titles to public MCP tools

### DIFF
--- a/src/lean_explore/mcp/tools.py
+++ b/src/lean_explore/mcp/tools.py
@@ -261,7 +261,10 @@ async def search(
     return response.model_dump(exclude_none=True)
 
 
-@mcp_app.tool(annotations=READ_ONLY_TOOL_ANNOTATIONS)
+@mcp_app.tool(
+    title="Search Lean declaration summaries",
+    annotations=READ_ONLY_TOOL_ANNOTATIONS,
+)
 async def search_summary(
     ctx: MCPContext,
     query: str,
@@ -334,7 +337,10 @@ async def search_summary(
     return summary_response.model_dump(exclude_none=True)
 
 
-@mcp_app.tool(annotations=READ_ONLY_TOOL_ANNOTATIONS)
+@mcp_app.tool(
+    title="Get Lean source code",
+    annotations=READ_ONLY_TOOL_ANNOTATIONS,
+)
 async def get_source_code(
     ctx: MCPContext,
     declaration_id: int,
@@ -370,7 +376,10 @@ async def get_source_code(
     )
 
 
-@mcp_app.tool(annotations=READ_ONLY_TOOL_ANNOTATIONS)
+@mcp_app.tool(
+    title="Get source link",
+    annotations=READ_ONLY_TOOL_ANNOTATIONS,
+)
 async def get_source_link(
     ctx: MCPContext,
     declaration_id: int,
@@ -406,7 +415,10 @@ async def get_source_link(
     )
 
 
-@mcp_app.tool(annotations=READ_ONLY_TOOL_ANNOTATIONS)
+@mcp_app.tool(
+    title="Get declaration docstring",
+    annotations=READ_ONLY_TOOL_ANNOTATIONS,
+)
 async def get_docstring(
     ctx: MCPContext,
     declaration_id: int,
@@ -443,7 +455,10 @@ async def get_docstring(
     )
 
 
-@mcp_app.tool(annotations=READ_ONLY_TOOL_ANNOTATIONS)
+@mcp_app.tool(
+    title="Get declaration description",
+    annotations=READ_ONLY_TOOL_ANNOTATIONS,
+)
 async def get_description(
     ctx: MCPContext,
     declaration_id: int,
@@ -479,7 +494,10 @@ async def get_description(
     )
 
 
-@mcp_app.tool(annotations=READ_ONLY_TOOL_ANNOTATIONS)
+@mcp_app.tool(
+    title="Get declaration module",
+    annotations=READ_ONLY_TOOL_ANNOTATIONS,
+)
 async def get_module(
     ctx: MCPContext,
     declaration_id: int,
@@ -514,7 +532,10 @@ async def get_module(
     )
 
 
-@mcp_app.tool(annotations=READ_ONLY_TOOL_ANNOTATIONS)
+@mcp_app.tool(
+    title="Get declaration dependencies",
+    annotations=READ_ONLY_TOOL_ANNOTATIONS,
+)
 async def get_dependencies(
     ctx: MCPContext,
     declaration_id: int,

--- a/tests/mcp/tools_test.py
+++ b/tests/mcp/tools_test.py
@@ -118,6 +118,7 @@ class TestSearchTool:
 
         assert len(registered_tools) == 8
         for tool in registered_tools:
+            assert tool.title
             assert tool.annotations is not None
             assert tool.annotations.readOnlyHint is True
             assert tool.annotations.destructiveHint is False


### PR DESCRIPTION
## Summary

- add human-readable titles to search_summary and all six per-field retrieval tools
- retain the deprecated compatibility title on search
- require every registered MCP tool to advertise a non-empty title in tests

Anthropic currently requires every Connectors Directory tool to include a title plus the applicable read-only or destructive annotations. The live endpoint already has the annotations, but only the deprecated search tool had a title.

## Verification

- .venv/bin/pytest tests/mcp/tools_test.py -q (48 passed)
- .venv/bin/ruff check src/lean_explore/mcp/tools.py tests/mcp/tools_test.py
- .venv/bin/ruff format --check src/lean_explore/mcp/tools.py tests/mcp/tools_test.py
- git diff --check